### PR TITLE
Fix invalid free in hostnameToIPAddr

### DIFF
--- a/src/utils/network.cpp
+++ b/src/utils/network.cpp
@@ -13,11 +13,12 @@ std::string hostnameToIPAddr(const std::string &host)
     char cAddr[128] = {};
     struct sockaddr_in *target;
     struct sockaddr_in6 *target6;
-    struct addrinfo hint = {}, *retAddrInfo, *cur;
+    struct addrinfo hint = {}, *retAddrInfo = nullptr, *cur;
     retVal = getaddrinfo(host.data(), NULL, &hint, &retAddrInfo);
     if(retVal != 0)
     {
-        freeaddrinfo(retAddrInfo);
+        if(retAddrInfo)
+            freeaddrinfo(retAddrInfo);
         return "";
     }
 


### PR DESCRIPTION
## Summary
- handle getaddrinfo failure in `hostnameToIPAddr`

## Testing
- `cmake -S . -B build` *(fails: Findtoml11.cmake missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fa9011e148325bd17982b026e222e