### PR TITLE
Fix typo in quickjspp comments

### DIFF
--- a/include/quickjspp.hpp
+++ b/include/quickjspp.hpp
@@ -35,7 +35,7 @@ class Context;
 class Value;
 
 /** Exception type.
- * Indicates that exception has occured in JS context.
+ * Indicates that exception has occurred in JS context.
  */
 class exception {
     JSContext * ctx;


### PR DESCRIPTION
## Summary
- fix small typo in comment about JS context exceptions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683faa251df88325b965937925c4c538