### PR TITLE
Fix logging warning usage

### DIFF
--- a/scripts/update_rules.py
+++ b/scripts/update_rules.py
@@ -27,7 +27,7 @@ def update_rules(repo_path: str, save_path: str, matches: list[str], keep_tree: 
     for pattern in matches:
         files = glob.glob(os.path.join(repo_path, pattern), recursive=True)
         if len(files) == 0:
-            logging.warn(f"no files found for pattern {pattern}")
+            logging.warning(f"no files found for pattern {pattern}")
             continue
         for file in files:
             if os.path.isdir(file):


### PR DESCRIPTION
## Summary
- fix deprecated call to `logging.warn` in `scripts/update_rules.py`

## Testing
- `python3 -m py_compile scripts/update_rules.py`


------
https://chatgpt.com/codex/tasks/task_e_683faa29763c8325828ad46cfe1e1ae9