### PR TITLE
Fix file reading bug

### DIFF
--- a/cmake/Findtoml11.cmake
+++ b/cmake/Findtoml11.cmake
@@ -1,0 +1,14 @@
+find_path(toml11_INCLUDE_DIR
+    NAMES toml.hpp
+    PATH_SUFFIXES include
+    PATHS ${toml11_ROOT} $ENV{toml11_ROOT}
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(toml11 DEFAULT_MSG toml11_INCLUDE_DIR)
+
+if(toml11_FOUND)
+    set(toml11_INCLUDE_DIRS ${toml11_INCLUDE_DIR})
+endif()
+
+mark_as_advanced(toml11_INCLUDE_DIR toml11_INCLUDE_DIRS)

--- a/src/utils/file.cpp
+++ b/src/utils/file.cpp
@@ -38,9 +38,12 @@ std::string fileGet(const std::string &path, bool scope_limit)
         content.assign(data, tot);
         delete[] data;
         */
-        content.resize(tot);
-        std::rewind(fp);
-        std::fread(&content[0], 1, tot, fp);
+        if(tot > 0)
+        {
+            content.resize(tot);
+            std::rewind(fp);
+            std::fread(&content[0], 1, tot, fp);
+        }
         std::fclose(fp);
     }
 


### PR DESCRIPTION
## Summary
- avoid invalid memory access when reading empty files
- add missing `Findtoml11.cmake` to detect toml11 headers

## Testing
- `cmake ..` *(fails: could not find toml11)*

------
https://chatgpt.com/codex/tasks/task_e_683fb053519c8325895dd2d7fe215fa1